### PR TITLE
Phase out use of EC2 module for CI tests

### DIFF
--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -19,23 +19,30 @@ module "customer_notifications" {
   topic_name = "CWAlarm-Test-${random_string.rstring.result}"
 }
 
-module "ec2_ar1" {
-  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=master"
-  ec2_os              = "amazon2"
-  subnets             = "${module.vpc.private_subnets}"
-  security_group_list = ["${module.vpc.default_sg}"]
-  instance_type       = "t2.micro"
-  resource_name       = "CWAlarm-Test1-${random_string.rstring.result}"
+data "aws_ami" "cent7" {
+  most_recent = true
+  owners      = ["679593333241"]
+
+  filter {
+    name   = "name"
+    values = ["CentOS Linux 7 x86_64 HVM EBS*"]
+  }
 }
 
-module "ec2_ar2" {
-  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=master"
-  ec2_os              = "ubuntu16"
-  instance_count      = "2"
-  subnets             = "${module.vpc.private_subnets}"
-  security_group_list = ["${module.vpc.default_sg}"]
-  instance_type       = "t2.micro"
-  resource_name       = "CWAlarm-Test2-${random_string.rstring.result}"
+resource "aws_instance" "ar1" {
+  ami                    = "${data.aws_ami.cent7.id}"
+  instance_type          = "t2.micro"
+  subnet_id              = "${module.vpc.private_subnets[0]}"
+  vpc_security_group_ids = ["${module.vpc.default_sg}"]
+}
+
+resource "aws_instance" "ar2" {
+  count = 2
+
+  ami                    = "${data.aws_ami.cent7.id}"
+  instance_type          = "t2.micro"
+  subnet_id              = "${module.vpc.private_subnets[1]}"
+  vpc_security_group_ids = ["${module.vpc.default_sg}"]
 }
 
 ######################################
@@ -56,7 +63,7 @@ module "ar1_cpu_alarm" {
   threshold                = 90
 
   dimensions = [{
-    InstanceId = "${element(module.ec2_ar1.ar_instance_id_list, 0)}"
+    InstanceId = "${aws_instance.ar1.id}"
   }]
 }
 
@@ -79,7 +86,7 @@ module "ar1_network_out_alarm" {
   threshold               = 60000000
 
   dimensions = [{
-    InstanceId = "${element(module.ec2_ar1.ar_instance_id_list, 0)}"
+    InstanceId = "${aws_instance.ar1.id}"
   }]
 }
 
@@ -90,7 +97,7 @@ data "null_data_source" "alarm_dimensions" {
   count = 2
 
   inputs = {
-    InstanceId = "${element(module.ec2_ar2.ar_instance_id_list, count.index)}"
+    InstanceId = "${element(aws_instance.ar2.*.id, count.index)}"
     device     = "xvda1"
     fstype     = "ext4"
     path       = "/"


### PR DESCRIPTION
##### Corresponding Issue(s):
 - Prelude to Terraform conversion.  removes circular dependency between AR module and CloudWatch Alarm module.

##### Summary of change(s):

##### Reason for Change(s):

- If a bug, describe error scenario, including expected behavior and actual behavior.

- If an enhancement, describe the use case and the perceived benefit(s).

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

##### If input variables or output variables have changed or has been added, have you updated the README?

##### Do examples need to be updated based on changes?

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
