### PR TITLE
adding `name` variable and deprecating `alarm_name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ This module deploys a customized CloudWatch Alarm, for use in generating custome
 
 ```HCL
 module "alarm" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.0"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.1"
 
  alarm_description        = "High CPU usage."
- alarm_name               = "MyCloudWatchAlarm"
  comparison_operator      = "GreaterThanThreshold"
  customer_alarms_enabled  = true
  evaluation_periods       = 5
  metric_name              = "CPUUtilization"
  notification_topic       = [var.notification_topic]
+ name                     = "MyCloudWatchAlarm"
  namespace                = "AWS/EC2"
  period                   = 60
  rackspace_alarms_enabled = true
@@ -34,6 +34,18 @@ Full working references are available at [examples](examples)
 ## Terraform 0.12 upgrade
 
 There should be no changes required to move from previous versions of this module to version 0.12.0 or higher.
+## Module variables
+
+The following module variables changes have occurred:
+
+#### Deprecations
+- `alarm_name` - marked for deprecation as it no longer meets our style guide standards.
+
+#### Additions
+- `name` - introduced as a replacement for `alarm_name` to better align with our style guide standards.
+
+#### Removals
+- None
 
 ## Providers
 
@@ -47,13 +59,14 @@ There should be no changes required to move from previous versions of this modul
 |------|-------------|------|---------|:-----:|
 | alarm\_count | The number of alarms to create. | `number` | `1` | no |
 | alarm\_description | The description for the alarm. | `string` | `""` | no |
-| alarm\_name | The descriptive name for the alarm. This name must be unique within the user's AWS account | `string` | n/a | yes |
+| alarm\_name | The descriptive name for the alarm. This name must be unique within the user's AWS account. [**Deprecated** in favor of `name`]. It will be removed in future releases. `name` supercedes the `alarm_name`. Either `name` or `alarm_name` **must** contain a non-default value. | `string` | `""` | no |
 | comparison\_operator | The arithmetic operation to use when comparing the specified Statistic and Threshold. The specified Statistic value is used as the first operand. Either of the following is supported: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold. | `string` | n/a | yes |
 | customer\_alarms\_cleared | Specifies whether alarms will notify customers when returning to an OK status. | `bool` | `false` | no |
 | customer\_alarms\_enabled | Specifies whether alarms will notify customers.  Automatically enabled if rackspace\_managed is set to false | `bool` | `false` | no |
 | dimensions | The list of dimensions for the alarm's associated metric. For the list of available dimensions see the AWS documentation here. | `list(map(string))` | n/a | yes |
 | evaluation\_periods | The number of periods over which data is compared to the specified threshold. | `number` | n/a | yes |
 | metric\_name | The name for the alarm's associated metric. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html for supported metrics. | `string` | n/a | yes |
+| name | The descriptive name for the alarm. This name must be unique within the user's AWS account. `name` supercedes the deprecated `alarm_name`. Either `name` or `alarm_name` **must** contain a non-default value. | `string` | `""` | no |
 | namespace | The namespace for the alarm's associated metric. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/aws-namespaces.html for the list of namespaces. | `string` | n/a | yes |
 | notification\_topic | List of SNS Topic ARNs to use for customer notifications. | `list(string)` | `[]` | no |
 | period | The period in seconds over which the specified statistic is applied. | `number` | `60` | no |

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -8,19 +8,19 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.12.1"
 
   name = "EC2-AR-BaseNetwork-Test1"
 }
 
 module "customer_notifications" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-sns//?ref=v0.12.1"
 
   name = "my-notification-topic"
 }
 
 module "ec2_ar1" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.4"
 
   ec2_os              = "amazon2"
   instance_type       = "t2.micro"
@@ -30,10 +30,10 @@ module "ec2_ar1" {
 }
 
 module "ec2_ar2" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_autorecovery?ref=v0.12.4"
 
   ec2_os              = "ubuntu16"
-  instance_count      = "2"
+  instance_count      = 2
   instance_type       = "t2.micro"
   name                = "test_ubuntu"
   security_group_list = [module.vpc.default_sg]
@@ -44,10 +44,10 @@ module "ec2_ar2" {
 # CWAlarm to create Rackspace Ticket #
 ######################################
 module "ar1_cpu_alarm" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.1"
 
   alarm_description        = "High CPU Usage on AR1."
-  alarm_name               = "CPUAlarmHigh-AR1"
+  name                     = "CPUAlarmHigh-AR1"
   comparison_operator      = "GreaterThanThreshold"
   evaluation_periods       = 10
   metric_name              = "CPUUtilization"
@@ -69,10 +69,10 @@ module "ar1_cpu_alarm" {
 # CWAlarm to notify customer #
 ##############################
 module "ar1_network_out_alarm" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.1"
 
   alarm_description       = "High Outbound Network traffic > 1MBps."
-  alarm_name              = "NetworkOutAlarmHigh-AR1"
+  name                    = "NetworkOutAlarmHigh-AR1"
   customer_alarms_enabled = true
   comparison_operator     = "GreaterThanThreshold"
   evaluation_periods      = 10
@@ -105,11 +105,11 @@ data "null_data_source" "alarm_dimensions" {
 }
 
 module "ar2_disk_usage_alarm" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.1"
 
   alarm_count              = "2"
   alarm_description        = "High Disk usage."
-  alarm_name               = "HighDiskUsageAlarm-AR2"
+  name                     = "HighDiskUsageAlarm-AR2"
   comparison_operator      = "GreaterThanOrEqualToThreshold"
   dimensions               = data.null_data_source.alarm_dimensions.*.outputs
   evaluation_periods       = 30

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -25,18 +25,18 @@ module "customer_notifications" {
   name = "CWAlarm-Test-${random_string.rstring.result}"
 }
 
-data "aws_ami" "cent7" {
+data "aws_ami" "ubuntu18" {
   most_recent = true
-  owners      = ["679593333241"]
+  owners      = ["099720109477"]
 
   filter {
     name   = "name"
-    values = ["CentOS Linux 7 x86_64 HVM EBS*"]
+    values = ["ubuntu/images/hvm-ssd/*ubuntu-bionic-18.04-amd64-server*"]
   }
 }
 
 resource "aws_instance" "ar1" {
-  ami                    = data.aws_ami.cent7.id
+  ami                    = data.aws_ami.ubuntu18.id
   instance_type          = "t2.micro"
   subnet_id              = module.vpc.private_subnets[0]
   vpc_security_group_ids = [module.vpc.default_sg]
@@ -45,7 +45,7 @@ resource "aws_instance" "ar1" {
 resource "aws_instance" "ar2" {
   count = 2
 
-  ami                    = data.aws_ami.cent7.id
+  ami                    = data.aws_ami.ubuntu18.id
   instance_type          = "t2.micro"
   subnet_id              = module.vpc.private_subnets[1]
   vpc_security_group_ids = [module.vpc.default_sg]

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -58,10 +58,10 @@ module "ar1_cpu_alarm" {
   source = "../../module"
 
   alarm_description        = "High CPU Usage on AR1."
-  alarm_name               = "CPUAlarmHigh-AR1-${random_string.rstring.result}"
   comparison_operator      = "GreaterThanThreshold"
   evaluation_periods       = 10
   metric_name              = "CPUUtilization"
+  name                     = "CPUAlarmHigh-AR1-${random_string.rstring.result}"
   namespace                = "AWS/EC2"
   period                   = 60
   rackspace_alarms_enabled = true
@@ -82,11 +82,11 @@ module "ar1_network_out_alarm" {
   source = "../../module"
 
   alarm_description       = "High Outbound Network traffic > 1MBps."
-  alarm_name              = "NetworkOutAlarmHigh-AR1-${random_string.rstring.result}"
   customer_alarms_enabled = true
   comparison_operator     = "GreaterThanThreshold"
   evaluation_periods      = 10
   metric_name             = "NetworkOut"
+  name                    = "NetworkOutAlarmHigh-AR1-${random_string.rstring.result}"
   namespace               = "AWS/EC2"
   notification_topic      = [module.customer_notifications.topic_arn]
   period                  = 60
@@ -117,13 +117,13 @@ data "null_data_source" "alarm_dimensions" {
 module "ar2_disk_usage_alarm" {
   source = "../../module"
 
-  alarm_count              = "2"
+  alarm_count              = 2
   alarm_description        = "High Disk usage."
-  alarm_name               = "HighDiskUsageAlarm-AR2-${random_string.rstring.result}"
   comparison_operator      = "GreaterThanOrEqualToThreshold"
   dimensions               = data.null_data_source.alarm_dimensions.*.outputs
   evaluation_periods       = 30
   metric_name              = "disk_used_percent"
+  name                     = "HighDiskUsageAlarm-AR2-${random_string.rstring.result}"
   namespace                = "System/Linux"
   period                   = 60
   rackspace_alarms_enabled = true

--- a/variables.tf
+++ b/variables.tf
@@ -11,8 +11,9 @@ variable "alarm_description" {
 }
 
 variable "alarm_name" {
-  description = "The descriptive name for the alarm. This name must be unique within the user's AWS account"
+  description = " The descriptive name for the alarm. This name must be unique within the user's AWS account. [**Deprecated** in favor of `name`]. It will be removed in future releases. `name` supercedes the `alarm_name`. Either `name` or `alarm_name` **must** contain a non-default value."
   type        = string
+  default     = ""
 }
 
 variable "comparison_operator" {
@@ -45,6 +46,12 @@ variable "evaluation_periods" {
 variable "metric_name" {
   description = "The name for the alarm's associated metric. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html for supported metrics."
   type        = string
+}
+
+variable "name" {
+  description = "The descriptive name for the alarm. This name must be unique within the user's AWS account. `name` supercedes the deprecated `alarm_name`. Either `name` or `alarm_name` **must** contain a non-default value."
+  type        = string
+  default     = ""
 }
 
 variable "namespace" {


### PR DESCRIPTION
##### Corresponding Issue(s):
- https://jira.rax.io/browse/MPCSUPENG-1012

##### Summary of change(s):
- deprecate `alarm_name`
- introduce `name` in place of `alarm_name` to align with style guide

##### Reason for Change(s):
- Style guide adherence.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
no
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
yes
##### Do examples need to be updated based on changes?
yes
