### PR TITLE
Add variable for treat_missing_data field (HCL1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,64 @@
-# aws-terraform-cloudwatch_alarm
+# aws-terraform-cloudwatch\_alarm  
 This module deploys a customized CloudWatch Alarm, for use in generating customer notifications or Rackspace support tickets.
 
 ## Basic Usage
 
 ```
 module "alarm" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.2"
 
- alarm_description        = "High CPU usage."
- alarm_name               = "MyCloudWatchAlarm"
- comparison_operator      = "GreaterThanThreshold"
- customer_alarms_enabled  = true
- evaluation_periods       = 5
- metric_name              = "CPUUtilization"
- notification_topic       = ["${var.notification_topic}"]
- namespace                = "AWS/EC2"
- period                   = 60
- rackspace_alarms_enabled = true
- rackspace_managed        = true
- severity                 = "urgent"
- statistic                = "Average"
- threshold                = 90
+  alarm_description        = "High CPU usage."
+  alarm_name               = "MyCloudWatchAlarm"
+  comparison_operator      = "GreaterThanThreshold"
+  customer_alarms_enabled  = true
+  evaluation_periods       = 5
+  metric_name              = "CPUUtilization"
+  notification_topic       = ["${var.notification_topic}"]
+  namespace                = "AWS/EC2"
+  period                   = 60
+  rackspace_alarms_enabled = true
+  rackspace_managed        = true
+  severity                 = "urgent"
+  statistic                = "Average"
+  threshold                = 90
 
- dimension {
-   InstanceId = "i-123456"
- }
+  dimension {
+    InstanceId = "i-123456"
+  }
 }
 ```
 
 Full working references are available at [examples](examples)
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| alarm\_count | The number of alarms to create. | string | `"1"` | no |
-| alarm\_description | The description for the alarm. | string | `""` | no |
-| alarm\_name | The descriptive name for the alarm. This name must be unique within the user's AWS account | string | n/a | yes |
-| comparison\_operator | The arithmetic operation to use when comparing the specified Statistic and Threshold. The specified Statistic value is used as the first operand. Either of the following is supported: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold. | string | n/a | yes |
-| customer\_alarms\_cleared | Specifies whether alarms will notify customers when returning to an OK status. | string | `"false"` | no |
-| customer\_alarms\_enabled | Specifies whether alarms will notify customers.  Automatically enabled if rackspace_managed is set to false | string | `"false"` | no |
-| dimensions | The list of dimensions for the alarm's associated metric. For the list of available dimensions see the AWS documentation here. | list | n/a | yes |
-| evaluation\_periods | The number of periods over which data is compared to the specified threshold. | string | n/a | yes |
-| metric\_name | The name for the alarm's associated metric. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html for supported metrics. | string | n/a | yes |
-| namespace | The namespace for the alarm's associated metric. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/aws-namespaces.html for the list of namespaces. | string | n/a | yes |
-| notification\_topic | List of SNS Topic ARNs to use for customer notifications. | list | `<list>` | no |
-| period | The period in seconds over which the specified statistic is applied. | string | `"60"` | no |
-| rackspace\_alarms\_enabled | Specifies whether alarms will create a Rackspace ticket.  Ignored if rackspace_managed is set to false | string | `"false"` | no |
-| rackspace\_managed | Boolean parameter controlling if instance will be fully managed by Rackspace support teams, created CloudWatch alarms that generate tickets, and utilize Rackspace managed SSM documents. | string | `"true"` | no |
-| severity | The desired severity of the created Rackspace ticket.  Supported values include: standard, urgent, emergency | string | `"standard"` | no |
-| statistic | The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum | string | `"Average"` | no |
-| threshold | The value against which the specified statistic is compared. | string | n/a | yes |
-| unit | The unit for the alarm's associated metric | string | `""` | no |
+|------|-------------|------|---------|:-----:|
+| alarm\_count | The number of alarms to create. | `string` | `1` | no |
+| alarm\_description | The description for the alarm. | `string` | `""` | no |
+| alarm\_name | The descriptive name for the alarm. This name must be unique within the user's AWS account | `string` | n/a | yes |
+| comparison\_operator | The arithmetic operation to use when comparing the specified Statistic and Threshold. The specified Statistic value is used as the first operand. Either of the following is supported: GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold. | `string` | n/a | yes |
+| customer\_alarms\_cleared | Specifies whether alarms will notify customers when returning to an OK status. | `string` | `false` | no |
+| customer\_alarms\_enabled | Specifies whether alarms will notify customers.  Automatically enabled if rackspace\_managed is set to false | `string` | `false` | no |
+| dimensions | The list of dimensions for the alarm's associated metric. For the list of available dimensions see the AWS documentation here. | `list` | n/a | yes |
+| evaluation\_periods | The number of periods over which data is compared to the specified threshold. | `string` | n/a | yes |
+| metric\_name | The name for the alarm's associated metric. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html for supported metrics. | `string` | n/a | yes |
+| namespace | The namespace for the alarm's associated metric. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/aws-namespaces.html for the list of namespaces. | `string` | n/a | yes |
+| notification\_topic | List of SNS Topic ARNs to use for customer notifications. | `list` | `[]` | no |
+| period | The period in seconds over which the specified statistic is applied. | `string` | `60` | no |
+| rackspace\_alarms\_enabled | Specifies whether alarms will create a Rackspace ticket.  Ignored if rackspace\_managed is set to false | `string` | `false` | no |
+| rackspace\_managed | Boolean parameter controlling if instance will be fully managed by Rackspace support teams, created CloudWatch alarms that generate tickets, and utilize Rackspace managed SSM documents. | `string` | `true` | no |
+| severity | The desired severity of the created Rackspace ticket.  Supported values include: standard, urgent, emergency | `string` | `"standard"` | no |
+| statistic | The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum | `string` | `"Average"` | no |
+| threshold | The value against which the specified statistic is compared. | `string` | n/a | yes |
+| treat\_missing\_data | Sets how this alarm is to handle missing data points. The following values are supported: missing, ignore, breaching and notBreaching. Defaults to missing | `string` | `"missing"` | no |
+| unit | The unit for the alarm's associated metric | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -36,7 +36,7 @@ module "ec2_ar2" {
 # CWAlarm to create Rackspace Ticket #
 ######################################
 module "ar1_cpu_alarm" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.2"
 
   alarm_description        = "High CPU Usage on AR1."
   alarm_name               = "CPUAlarmHigh-AR1"
@@ -59,7 +59,7 @@ module "ar1_cpu_alarm" {
 # CWAlarm to notify customer #
 ##############################
 module "ar1_network_out_alarm" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.2"
 
   alarm_description       = "High Outbound Network traffic > 1MBps."
   alarm_name              = "NetworkOutAlarmHigh-AR1"
@@ -93,7 +93,7 @@ data "null_data_source" "alarm_dimensions" {
 }
 
 module "ar2_disk_usage_alarm" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.2"
 
   alarm_count              = "2"
   alarm_description        = "High Disk usage."

--- a/main.tf
+++ b/main.tf
@@ -1,33 +1,33 @@
 /**
  * # aws-terraform-cloudwatch_alarm
- *This module deploys a customized CloudWatch Alarm, for use in generating customer notifications or Rackspace support tickets.
+ * This module deploys a customized CloudWatch Alarm, for use in generating customer notifications or Rackspace support tickets.
  *
- *## Basic Usage
+ * ## Basic Usage
  *
- *```
- *module "alarm" {
- *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.1"
+ * ```
+ * module "alarm" {
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.0.2"
  *
- *  alarm_description        = "High CPU usage."
- *  alarm_name               = "MyCloudWatchAlarm"
- *  comparison_operator      = "GreaterThanThreshold"
- *  customer_alarms_enabled  = true
- *  evaluation_periods       = 5
- *  metric_name              = "CPUUtilization"
- *  notification_topic       = ["${var.notification_topic}"]
- *  namespace                = "AWS/EC2"
- *  period                   = 60
- *  rackspace_alarms_enabled = true
- *  rackspace_managed        = true
- *  severity                 = "urgent"
- *  statistic                = "Average"
- *  threshold                = 90
+ *   alarm_description        = "High CPU usage."
+ *   alarm_name               = "MyCloudWatchAlarm"
+ *   comparison_operator      = "GreaterThanThreshold"
+ *   customer_alarms_enabled  = true
+ *   evaluation_periods       = 5
+ *   metric_name              = "CPUUtilization"
+ *   notification_topic       = ["${var.notification_topic}"]
+ *   namespace                = "AWS/EC2"
+ *   period                   = 60
+ *   rackspace_alarms_enabled = true
+ *   rackspace_managed        = true
+ *   severity                 = "urgent"
+ *   statistic                = "Average"
+ *   threshold                = 90
  *
- *  dimension {
- *    InstanceId = "i-123456"
- *  }
- *}
- *```
+ *   dimension {
+ *     InstanceId = "i-123456"
+ *   }
+ * }
+ * ```
  *
  * Full working references are available at [examples](examples)
  *
@@ -74,6 +74,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
   period              = "${var.period}"
   statistic           = "${var.statistic}"
   threshold           = "${var.threshold}"
+  treat_missing_data  = "${var.treat_missing_data}"
   unit                = "${var.unit}"
 
   alarm_actions = ["${concat(local.rackspace_alarm_actions[local.rackspace_alarm_config],

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,12 @@ variable "threshold" {
   type        = "string"
 }
 
+variable "treat_missing_data" {
+  description = "Sets how this alarm is to handle missing data points. The following values are supported: missing, ignore, breaching and notBreaching. Defaults to missing"
+  type        = "string"
+  default     = "missing"
+}
+
 variable "unit" {
   description = "The unit for the alarm's associated metric"
   type        = "string"


### PR DESCRIPTION
##### Corresponding Issue(s):
 - [MPCSUPENG-1622](https://jira.rax.io/browse/MPCSUPENG-1622)

##### Summary of change(s):
Introduces variable to set `aws_cloudwatch_metric_alarm` field `treat_missing_data` and defaults field to the current `missing` value

##### Reason for Change(s):

- Change allows more customization of alarms.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No resource destruction or changes should occur.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No

##### If input variables or output variables have changed or has been added, have you updated the README?
Yes
##### Do examples need to be updated based on changes?
Yes, included in this PR

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
