### PR TITLE
Add variable for treat_missing_data field (HCL2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module deploys a customized CloudWatch Alarm, for use in generating custome
 
 ```HCL
 module "alarm" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.1"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.4"
 
  alarm_description        = "High CPU usage."
  comparison_operator      = "GreaterThanThreshold"
@@ -75,6 +75,7 @@ The following module variables changes have occurred:
 | severity | The desired severity of the created Rackspace ticket.  Supported values include: standard, urgent, emergency | `string` | `"standard"` | no |
 | statistic | The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum | `string` | `"Average"` | no |
 | threshold | The value against which the specified statistic is compared. | `string` | n/a | yes |
+| treat\_missing\_data | Sets how this alarm is to handle missing data points. The following values are supported: missing, ignore, breaching and notBreaching. Defaults to missing | `string` | `"missing"` | no |
 | unit | The unit for the alarm's associated metric | `string` | `""` | no |
 
 ## Outputs

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -44,7 +44,7 @@ module "ec2_ar2" {
 # CWAlarm to create Rackspace Ticket #
 ######################################
 module "ar1_cpu_alarm" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.4"
 
   alarm_description        = "High CPU Usage on AR1."
   name                     = "CPUAlarmHigh-AR1"
@@ -69,7 +69,7 @@ module "ar1_cpu_alarm" {
 # CWAlarm to notify customer #
 ##############################
 module "ar1_network_out_alarm" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.4"
 
   alarm_description       = "High Outbound Network traffic > 1MBps."
   name                    = "NetworkOutAlarmHigh-AR1"
@@ -105,7 +105,7 @@ data "null_data_source" "alarm_dimensions" {
 }
 
 module "ar2_disk_usage_alarm" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.4"
 
   alarm_count              = "2"
   alarm_description        = "High Disk usage."

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,13 @@
 /**
  * # aws-terraform-cloudwatch_alarm
- * 
+ *
  * This module deploys a customized CloudWatch Alarm, for use in generating customer notifications or Rackspace support tickets.
- * 
+ *
  * ## Basic Usage
- * 
+ *
  * ```HCL
  * module "alarm" {
- *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.1"
+ *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.4"
  *
  *  alarm_description        = "High CPU usage."
  *  comparison_operator      = "GreaterThanThreshold"
@@ -36,15 +36,15 @@
  *
  * There should be no changes required to move from previous versions of this module to version 0.12.0 or higher.
  * ## Module variables
-* 
+*
 * The following module variables changes have occurred:
-* 
+*
 * #### Deprecations
 * - `alarm_name` - marked for deprecation as it no longer meets our style guide standards.
-* 
+*
 * #### Additions
 * - `name` - introduced as a replacement for `alarm_name` to better align with our style guide standards.
-* 
+*
 * #### Removals
 * - None
 */
@@ -98,6 +98,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
   period              = var.period
   statistic           = var.statistic
   threshold           = var.threshold
+  treat_missing_data  = var.treat_missing_data
   unit                = var.unit
 
   alarm_actions = concat(

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -130,4 +130,5 @@ module "ar2_disk_usage_alarm" {
   severity                 = "standard"
   statistic                = "Average"
   threshold                = 80
+  treat_missing_data       = "notBreaching"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -100,6 +100,12 @@ variable "threshold" {
   type        = string
 }
 
+variable "treat_missing_data" {
+  description = "Sets how this alarm is to handle missing data points. The following values are supported: missing, ignore, breaching and notBreaching. Defaults to missing"
+  type        = string
+  default     = "missing"
+}
+
 variable "unit" {
   description = "The unit for the alarm's associated metric"
   type        = string


### PR DESCRIPTION
##### Corresponding Issue(s):
 - [MPCSUPENG-1622](https://jira.rax.io/browse/MPCSUPENG-1622)

##### Summary of change(s):
Introduces variable to set `aws_cloudwatch_metric_alarm` field `treat_missing_data` and defaults field to the current `missing` value

##### Reason for Change(s):

- Change allows more customization of alarms.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No resource destruction or changes should occur.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No

##### If input variables or output variables have changed or has been added, have you updated the README?
Yes
##### Do examples need to be updated based on changes?
Yes, included in this PR

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
