### PR TITLE
More custom alarms if many are created

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The following module variables changes have occurred:
 | evaluation\_periods | The number of periods over which data is compared to the specified threshold. | `number` | n/a | yes |
 | metric\_name | The name for the alarm's associated metric. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html for supported metrics. | `string` | n/a | yes |
 | name | The descriptive name for the alarm. This name must be unique within the user's AWS account. `name` supercedes the deprecated `alarm_name`. Either `name` or `alarm_name` **must** contain a non-default value. | `string` | `""` | no |
+| name\_suffixes | Used to better distinguish similar alarms by replace 001 etc with given suffix. | `list(string)` | `[]` | no |
 | namespace | The namespace for the alarm's associated metric. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/aws-namespaces.html for the list of namespaces. | `string` | n/a | yes |
 | notification\_topic | List of SNS Topic ARNs to use for customer notifications. | `list(string)` | `[]` | no |
 | period | The period in seconds over which the specified statistic is applied. | `number` | `60` | no |
@@ -74,7 +75,8 @@ The following module variables changes have occurred:
 | rackspace\_managed | Boolean parameter controlling if instance will be fully managed by Rackspace support teams, created CloudWatch alarms that generate tickets, and utilize Rackspace managed SSM documents. | `bool` | `true` | no |
 | severity | The desired severity of the created Rackspace ticket.  Supported values include: standard, urgent, emergency | `string` | `"standard"` | no |
 | statistic | The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum | `string` | `"Average"` | no |
-| threshold | The value against which the specified statistic is compared. | `string` | n/a | yes |
+| threshold | The value against which the specified statistic is compared. [**Deprecated** in favor of `name`]. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value. | `string` | n/a | yes |
+| thresholds | The values against which the specified statistic is compared per alarm. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value. | `string` | n/a | yes |
 | treat\_missing\_data | Sets how this alarm is to handle missing data points. The following values are supported: missing, ignore, breaching and notBreaching. Defaults to missing | `string` | `"missing"` | no |
 | unit | The unit for the alarm's associated metric | `string` | `""` | no |
 
@@ -83,4 +85,3 @@ The following module variables changes have occurred:
 | Name | Description |
 |------|-------------|
 | alarm\_id | List of created alarm names |
-

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The following module variables changes have occurred:
 | rackspace\_managed | Boolean parameter controlling if instance will be fully managed by Rackspace support teams, created CloudWatch alarms that generate tickets, and utilize Rackspace managed SSM documents. | `bool` | `true` | no |
 | severity | The desired severity of the created Rackspace ticket.  Supported values include: standard, urgent, emergency | `string` | `"standard"` | no |
 | statistic | The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum | `string` | `"Average"` | no |
-| threshold | The value against which the specified statistic is compared. [**Deprecated** in favor of `name`]. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value. | `string` | n/a | yes |
+| threshold | The value against which the specified statistic is compared. [**Deprecated** in favor of `name`]. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value. | `string` | `""` | no |
 | thresholds | The values against which the specified statistic is compared per alarm. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value. | `list(string)` | `[]` | no |
 | treat\_missing\_data | Sets how this alarm is to handle missing data points. The following values are supported: missing, ignore, breaching and notBreaching. Defaults to missing | `string` | `"missing"` | no |
 | unit | The unit for the alarm's associated metric | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following module variables changes have occurred:
 | severity | The desired severity of the created Rackspace ticket.  Supported values include: standard, urgent, emergency | `string` | `"standard"` | no |
 | statistic | The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum | `string` | `"Average"` | no |
 | threshold | The value against which the specified statistic is compared. [**Deprecated** in favor of `name`]. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value. | `string` | n/a | yes |
-| thresholds | The values against which the specified statistic is compared per alarm. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value. | `string` | n/a | yes |
+| thresholds | The values against which the specified statistic is compared per alarm. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value. | `string` | `[]` | no |
 | treat\_missing\_data | Sets how this alarm is to handle missing data points. The following values are supported: missing, ignore, breaching and notBreaching. Defaults to missing | `string` | `"missing"` | no |
 | unit | The unit for the alarm's associated metric | `string` | `""` | no |
 

--- a/README.md
+++ b/README.md
@@ -85,3 +85,4 @@ The following module variables changes have occurred:
 | Name | Description |
 |------|-------------|
 | alarm\_id | List of created alarm names |
+

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following module variables changes have occurred:
 | severity | The desired severity of the created Rackspace ticket.  Supported values include: standard, urgent, emergency | `string` | `"standard"` | no |
 | statistic | The statistic to apply to the alarm's associated metric. Either of the following is supported: SampleCount, Average, Sum, Minimum, Maximum | `string` | `"Average"` | no |
 | threshold | The value against which the specified statistic is compared. [**Deprecated** in favor of `name`]. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value. | `string` | n/a | yes |
-| thresholds | The values against which the specified statistic is compared per alarm. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value. | `string` | `[]` | no |
+| thresholds | The values against which the specified statistic is compared per alarm. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value. | `list(string)` | `[]` | no |
 | treat\_missing\_data | Sets how this alarm is to handle missing data points. The following values are supported: missing, ignore, breaching and notBreaching. Defaults to missing | `string` | `"missing"` | no |
 | unit | The unit for the alarm's associated metric | `string` | `""` | no |
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -110,6 +110,7 @@ module "ar2_disk_usage_alarm" {
   alarm_count              = "2"
   alarm_description        = "High Disk usage."
   name                     = "HighDiskUsageAlarm-AR2"
+  name_suffixes            = ["diska", "diskb"]
   comparison_operator      = "GreaterThanOrEqualToThreshold"
   dimensions               = data.null_data_source.alarm_dimensions.*.outputs
   evaluation_periods       = 30
@@ -119,5 +120,5 @@ module "ar2_disk_usage_alarm" {
   rackspace_alarms_enabled = true
   severity                 = "standard"
   statistic                = "Average"
-  threshold                = 80
+  thresholds               = [80, 70]
 }

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
   count = var.alarm_count
 
   alarm_description   = var.alarm_description
-  alarm_name          = var.alarm_count > 1 ? format("%v-%03d", local.alarm_name, count.index + 1) : local.alarm_name
+  alarm_name          = var.alarm_count > 1 ? format("%v-%03d", local.alarm_name, length(var.name_suffixes) == 0 ? count.index + 1 : var.name_suffixes[count.index]) : local.alarm_name
   comparison_operator = var.comparison_operator
   dimensions          = var.dimensions[count.index]
   evaluation_periods  = var.evaluation_periods
@@ -97,7 +97,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
   namespace           = var.namespace
   period              = var.period
   statistic           = var.statistic
-  threshold           = var.threshold
+  threshold           = length(var.thresholds) == 0 ? var.threshold : var.thresholds
   treat_missing_data  = var.treat_missing_data
   unit                = var.unit
 

--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
   namespace           = var.namespace
   period              = var.period
   statistic           = var.statistic
-  threshold           = length(var.thresholds) == 0 ? var.threshold : var.thresholds
+  threshold           = length(var.thresholds) == 0 ? var.threshold : var.thresholds[count.index]
   treat_missing_data  = var.treat_missing_data
   unit                = var.unit
 

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
   count = var.alarm_count
 
   alarm_description   = var.alarm_description
-  alarm_name          = var.alarm_count > 1 ? format("%v-%03d", local.alarm_name, length(var.name_suffixes) == 0 ? count.index + 1 : var.name_suffixes[count.index]) : local.alarm_name
+  alarm_name          = var.alarm_count > 1 ? format("%v-%v", local.alarm_name, length(var.name_suffixes) == 0 ? format("%03d", count.index + 1) : var.name_suffixes[count.index]) : local.alarm_name
   comparison_operator = var.comparison_operator
   dimensions          = var.dimensions[count.index]
   evaluation_periods  = var.evaluation_periods

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -119,6 +119,7 @@ module "ar2_disk_usage_alarm" {
 
   alarm_count              = 2
   alarm_description        = "High Disk usage."
+  name_suffixes            = ["diska", "diskb"]
   comparison_operator      = "GreaterThanOrEqualToThreshold"
   dimensions               = data.null_data_source.alarm_dimensions.*.outputs
   evaluation_periods       = 30
@@ -129,6 +130,6 @@ module "ar2_disk_usage_alarm" {
   rackspace_alarms_enabled = true
   severity                 = "standard"
   statistic                = "Average"
-  threshold                = 80
+  thresholds               = [80, 70]
   treat_missing_data       = "notBreaching"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -108,7 +108,7 @@ variable "threshold" {
 
 variable "thresholds" {
   description = "The values against which the specified statistic is compared per alarm. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value."
-  type        = string
+  type        = list(string)
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -104,6 +104,7 @@ variable "statistic" {
 variable "threshold" {
   description = "The value against which the specified statistic is compared. [**Deprecated** in favor of `name`]. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value."
   type        = string
+  default     = ""
 }
 
 variable "thresholds" {

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,12 @@ variable "name" {
   default     = ""
 }
 
+variable "name_suffixes" {
+  description = "Used to better distinguish similar alarms by replace 001 etc with given suffix."
+  type        = list(string)
+  default     = []
+}
+
 variable "namespace" {
   description = "The namespace for the alarm's associated metric. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/aws-namespaces.html for the list of namespaces."
   type        = string
@@ -96,7 +102,12 @@ variable "statistic" {
 }
 
 variable "threshold" {
-  description = "The value against which the specified statistic is compared."
+  description = "The value against which the specified statistic is compared. [**Deprecated** in favor of `name`]. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value."
+  type        = string
+}
+
+variable "thresholds" {
+  description = "The values against which the specified statistic is compared per alarm. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value."
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -109,6 +109,7 @@ variable "threshold" {
 variable "thresholds" {
   description = "The values against which the specified statistic is compared per alarm. `thresholds` supercedes the depreciated `threshold`. Either `name` or `alarm_name` **must** contain a non-default value."
   type        = string
+  default     = []
 }
 
 variable "treat_missing_data" {


### PR DESCRIPTION
##### Corresponding Issue(s):
 - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section

##### Summary of change(s):
Module cannot create custom alarms that are similar.  E.g. an alarm per drive but different thresholds and more human friendly description.

##### Reason for Change(s):

- If a bug, describe error scenario, including expected behavior and actual behavior.

- If an enhancement, describe the use case and the perceived benefit(s).
Allows Name to go from `FreeSpacePercentage-001` to `FreeSpacePercentage-C` and to allow different thresholds for alarming.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No, `threshold` kept but depreciated in favour of `thresholds` and if no name suffixes specified then numbering `001` is used.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No

##### If input variables or output variables have changed or has been added, have you updated the README?
Updated

##### Do examples need to be updated based on changes?
Already done to last example/test

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
